### PR TITLE
Exclude deleted items from queries.

### DIFF
--- a/psql2mysql.py
+++ b/psql2mysql.py
@@ -171,7 +171,7 @@ class DbDataMigrator(object):
                 # huge transcation?
                 self.target_db.writeTableRows(target_tables[table.name], result)
             else:
-                LOG.info("Table '%s' is empty" % table.name)
+                LOG.debug("Table '%s' is empty" % table.name)
 
 
 def add_subcommands(subparsers):


### PR DESCRIPTION
- excluding deleted items should make the migration faster
- it is even necessary when user deletes the items that do not pass the precheck (like wrong UTF chars)