### PR TITLE
Fix query for "deleted" columns of type Boolean

### DIFF
--- a/psql2mysql.py
+++ b/psql2mysql.py
@@ -59,7 +59,7 @@ class DbWrapper(object):
             return query.where(table.c.deleted == 0)
         if isinstance(table.columns["deleted"].type, types.VARCHAR):
             return query.where(table.c.deleted == 'False')
-        return query.where(table.c.deleted is False)
+        return query.where(table.c.deleted.is_(False))
 
     def getTextColumns(self, table):
         columns = table.columns


### PR DESCRIPTION
It seems sqlalchemy doesn't really support the "boolean is False"
syntax. We need you use the "is_" function here.