### PR TITLE
Refactor into a module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/*.pyc
+.eggs
+psql2mysql.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ matrix:
     - python: "3.6"
 install: pip install -r requirements.txt -r test-requirements.txt
 script:
-    - flake8 *.py
+    - flake8 --filename="*.py"
     - nosetests

--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2
-#
 # (c) Copyright 2018, SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -344,7 +342,7 @@ def check_target_schema(target):
         sys.exit(1)
 
 
-if __name__ == '__main__':
+def main():
     # FIXME: Split these up into separate components?
     #   host, port, username, password, database
     cli_opts = [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='psql2mysql',
+    version='0.4.0',
+    description='Copy data from PostgreSQL databases to MySQL',
+    url='https://github.com/SUSE/psql2mysql',
+    author='SUSE LLC',
+    author_email='things@suse.com',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache License 2.0',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    packages=find_packages(exclude=['tests']),
+    install_requires=[
+        'oslo.config',
+        'oslo.log',
+        'psycopg2',
+        'prettytable',
+        'PyMySQL',
+        'rfc3986',
+        'SQLAlchemy<1.1.0,>=1.0.10',
+    ],
+    tests_requires=[
+        'flake8',
+        'mock',
+    ],
+    entry_points={
+        'console_scripts': [
+            'psql2mysql=psql2mysql:main',
+        ],
+    },
+)


### PR DESCRIPTION
Move the psql2mysql script into a module, moving the test under that
directory structure as well. Remove the importlib hack, since we no
longer need to pretend the script is a module, and replace the homegrown
test fakes with namedtuples. Also add a .gitignore for safety.