### PR TITLE
Add a ChunkedDBWrapper and chunked options

### DIFF
--- a/psql2mysql/tests/test_dbwrapper.py
+++ b/psql2mysql/tests/test_dbwrapper.py
@@ -82,3 +82,21 @@ class TestDbWrapper(unittest.TestCase):
         wrong_item = result[0]
         self.assertEqual("text", wrong_item["column"])
         self.assertEqual("id=3", wrong_item["primary"][0])
+
+
+class TestChuckedDbWrapper(TestDbWrapper):
+    def setUp(self):
+        self.uri = "postgresql://keystone:p@192.168.243.86/keystone"
+        self.path = ""
+        self.limit = 10
+        self.db_wrapper = psql2mysql.ChunkedDBWrapper(self.uri, self.path,
+                                                      self.limit)
+
+    def test_find_status(self):
+        pass
+
+    def test_close(self):
+        pass
+
+    def test_readTableRows(self):
+        pass


### PR DESCRIPTION
This patch adds some cli options to the migrate sub command:
  --chunked - To enable chunking mode (defaults to False)
  --chunk-size - to define the size of the chunks (defaults to 10000)
  --status-dir - To define a location so save migration status to.
                 (default /tmp/psql2mysql/)

And all this is implemented as a new DB wrapper. Chunking will
work if a table has a single primary key, if the primary key is
an int or varchar. However, varchars (UUIDs) chunking only works
if there is also a `created_at` field, that we can use for progress.
If none of that is possible, it'll fall back to entire table migrations.

I've held back on the tests, they're still on my machine as there
still more of a work in progress.
The code here grew uglier due to debugging and finding interesting
sql alchemy things. Might need to look back over and clean up and
refactor a little.