### PR TITLE
Raise Exception on precheck failures

### DIFF
--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -249,11 +249,12 @@ class DbDataMigrator(object):
 
         for table in source_tables:
             LOG.info("Migrating table: '%s'" % table.name)
-            self.setupTypeDecorators(table, target_tables[table.name])
             if table.name not in target_tables:
                 raise Psql2MysqlRuntimeError(
                     "Table '%s' does not exist in target database" %
                     table.name)
+
+            self.setupTypeDecorators(table, target_tables[table.name])
 
             # skip the schema migration related tables
             # FIXME: Should we put this into a config setting


### PR DESCRIPTION
This introduces a custom RuntimeError Exception that is raised if
something goes wrong during the prechecks or migration.

Addtionally we make sure to use a non-zero exit code if any of the
prechecks fail. And it case of batch processings we stop the batch
now after finding errors in a database.