### PR TITLE
add missing nosetest to test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 flake8
 mock
+nose


### PR DESCRIPTION
while it works on travis, as I guess it may have it preinstalled,
locally running the tests requires us to install the nose library