### PR TITLE
Enhance travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: python
-python:
- - "2.7"
- - "3.6"
-install: pip install -r requirements.txt -r test-requirements.txt
-script:
-    - flake8 --filename="*.py"
-    - nosetests
+install:
+  - pip install -r requirements.txt -r test-requirements.txt
+cache:
+  directories:
+    - $HOME/.cache/pip
+matrix:
+  include:
+    - name: "Python 2.7 tests"
+      python: "2.7"
+      script: nosetests
+    - name: "Python 2.7 flake8"
+      python: "2.7"
+      script: flake8 --filename="*.py"
+    - name: "Python 3.6 tests"
+      python: "3.6"
+      script: nosetests
+    - name: "Python 3.6 flake8"
+      python: "3.6"
+      script: flake8 --filename="*.py"


### PR DESCRIPTION
runs the tests and flake8 in separate builds, cache the pip dir for
faster builds, names the tests so its easier to check them

~~Note: Will not work yet as its missing the nosetests lib as provided in https://github.com/SUSE/psql2mysql/pull/35~~

~~Once that gets in, this should pass ~~

Disregard that, I was missing an `s` in the nose command :1st_place_medal: 