### PR TITLE
Drop positive_int() and related test

### DIFF
--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -203,12 +203,7 @@ class DbDataMigrator(object):
         self.cfg = config
         self.src_uri = source if source else cfg.CONF.source
         self.target_uri = target if target else cfg.CONF.target
-        try:
-            self.chunk_size = positive_int(chunk_size) \
-                if chunk_size is not None else cfg.CONF.chunk_size
-        except ValueError as e:
-            LOG.error(str(e))
-            raise
+        self.chunk_size = chunk_size if chunk_size else cfg.CONF.chunk_size
 
     def setup(self):
         self.src_db = DbWrapper(self.src_uri, self.chunk_size)
@@ -290,16 +285,6 @@ class DbDataMigrator(object):
                              col.name, col.type, targetCol.type,
                              decorator.__name__)
                     targetTable.c[targetCol.name].type = decorator
-
-
-def positive_int(value):
-    try:
-        if int(value) >= 0:
-            return int(value)
-        else:
-            raise ValueError()
-    except (ValueError, TypeError):
-        raise ValueError("{} must be a positive integer".format(value))
 
 
 def add_subcommands(subparsers):
@@ -437,7 +422,8 @@ def main():
         cfg.IntOpt('chunk-size',
                    default=10000,
                    min=0,
-                   help='Number of records to move per chunk.')
+                   help='Number of records to move per chunk. Set to 0 to '
+                        'disable, default is 10,000.')
     ]
 
     cfg.CONF.register_cli_opts(cli_opts)

--- a/psql2mysql/tests/test_dbdatamigrator.py
+++ b/psql2mysql/tests/test_dbdatamigrator.py
@@ -100,30 +100,3 @@ class TestDbDataMigrator(unittest.TestCase):
         dbdatamigrator.src_db.readTableRows.assert_called_with(foo)
         dbdatamigrator.target_db.clearTable.assert_called_with(foo)
         dbdatamigrator.target_db.writeTableRows.assert_called_once()
-
-    @mock.patch('psql2mysql.DbWrapper')
-    @mock.patch('psql2mysql.cfg.CONF')
-    def test_chuck_size(self, cfg_mock, dbwrapper_mock):
-        def test(chunk_size, expected):
-            if isinstance(expected, ValueError):
-                self.assertRaises(ValueError, psql2mysql.DbDataMigrator,
-                                  None, None, None, chunk_size)
-            else:
-                dbdatamigrator = psql2mysql.DbDataMigrator(None, None, None,
-                                                           chunk_size)
-                self.assertEqual(dbdatamigrator.chunk_size, expected)
-
-        dbwrapper_mock.connect.return_value = None
-        tests = ({"chunk_size": -1, "expected": ValueError()},
-                 {"chunk_size": "-1", "expected": ValueError()},
-                 {"chunk_size": "", "expected": ValueError()},
-                 {"chunk_size": 'not an int', "expected": ValueError()},
-                 {"chunk_size": 0, "expected": 0},
-                 {"chunk_size": "0", "expected": 0},
-                 {"chunk_size": "-0", "expected": 0},
-                 {"chunk_size": "+0", "expected": 0},
-                 {"chunk_size": "1", "expected": 1},
-                 {"chunk_size": 2, "expected": 2},
-                 {"chunk_size": "5", "expected": 5})
-        for params in tests:
-            test(**params)


### PR DESCRIPTION
oslo.config gives us enough safety with declaring a minimum of the
chunk-size option that we don't need to be extra careful checking if
it's a positive integer. Also make clear the behaviour of the chunk-size
option in the help string.

Ref: https://docs.openstack.org/oslo.config/latest/reference/opts.html