### PR TITLE
Change configured project name

### DIFF
--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -445,10 +445,10 @@ def main():
     logging.set_defaults()
 
     # read config and initialize logging
-    cfg.CONF(project='pg2my')
+    cfg.CONF(project='psql2mysql')
 #    cfg.CONF.set_override("use_stderr", True)
 
-    logging.setup(cfg.CONF, 'pg2my')
+    logging.setup(cfg.CONF, 'psql2mysql')
 
     # We expect batch file with this syntax:
     #


### PR DESCRIPTION
The project name passed into the oslo setup does not match either the
module name, nor the command line utility, change it so it does match.