### PR TITLE
Correct the license classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license = Apache-2
 classifier =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License 2.0
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3


### PR DESCRIPTION
The legacy classifier does not specify the version number for the Apache
license. https://github.com/pypa/warehouse/issues/2996 has all the tears
ever.