### PR TITLE
Drop version number, add description file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = psql2mysql
-version = 0.4.0
 summary = Copy data from PostgreSQL databases to MySQL
+description-file = README.md
 home-page = https://github.com/SUSE/psql2mysql
 license = Apache-2
 classifier =


### PR DESCRIPTION
Now that 0.4.0 is out the door, we can rely on git tags to keep the
version number up to date for us, and no longer need to hardcode it in
the config file. Also add a description-file so that we get a long
description.