### PR TITLE
Add pbr to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 oslo.config
 oslo.log
+pbr
 psycopg2
 prettytable
 PyMySQL


### PR DESCRIPTION
When the tooling was changed to using pbr, it was not added to the
requirements, do so now.