### PR TITLE
Set content-type for description-file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = psql2mysql
 summary = Copy data from PostgreSQL databases to MySQL
 description-file = README.md
+description-content-type = text/markdown
 home-page = https://github.com/SUSE/psql2mysql
 license = Apache-2
 classifier =


### PR DESCRIPTION
description-file for pbr will deal with restructed text and plain text
by default, but needs a helping hand for markdown. Add a content-type to
assist pbr.