### PR TITLE
Check if the source database is set

### DIFF
--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -504,6 +504,10 @@ def main():
         print("Batch processing done.")
         sys.exit(0)
 
+    if not cfg.CONF.source:
+        print("Source database was not specified.")
+        sys.exit(1)
+
     check_source_schema(cfg.CONF.source)
 
     if cfg.CONF.target:


### PR DESCRIPTION
If no arguments are specified, we give a nice help message. If a command
is given with no source database, we print a traceback when trying to
check the scheme of a URI of None. Check for that and exit instead.