### PR TITLE
Fix migration for Neutron

### DIFF
--- a/psql2mysql/__init__.py
+++ b/psql2mysql/__init__.py
@@ -246,7 +246,7 @@ class DbDataMigrator(object):
 
         for table in self.target_db.getSortedTables():
             if (table.name == "migrate_version" or
-                    table.name.startswith("alembic_")):
+                    "alembic_" in table.name):
                 continue
             self.target_db.clearTable(table)
 
@@ -278,7 +278,7 @@ class DbDataMigrator(object):
             # FIXME: Should we put this into a config setting
             # (e.g. --skiptables?)
             if (table.name == "migrate_version" or
-                    table.name.startswith("alembic_")):
+                    "alembic_" in table.name):
                 continue
 
             result = self.src_db.readTableRows(table)


### PR DESCRIPTION
Neutron drivers use own naming for alembic migrations, e.g.
cisco_alembic_version, aci_alembic_version, etc depending on driver.

Therefore we should check for all *alembic_* tables and not only those
which start with alembic_, otherwise those get purged and next DB
migration attempt will fail since schema is applied, but migration
version ids are back to initial ones.